### PR TITLE
Add convert rule for message context.

### DIFF
--- a/pojson/convert.py
+++ b/pojson/convert.py
@@ -13,11 +13,17 @@ def po2dict(po):
     for entry in po:
         if entry.obsolete:
             continue
+
+        if entry.msgctxt:
+            key = u'{0}\x04{1}'.format(entry.msgctxt, entry.msgid)
+        else:
+            key = entry.msgid
+
         if entry.msgstr:
-            result[entry.msgid] = [None, entry.msgstr]
+            result[key] = [None, entry.msgstr]
         elif entry.msgstr_plural:
             plural = [entry.msgid_plural]
-            result[entry.msgid] = plural
+            result[key] = plural
             ordered_plural = sorted(entry.msgstr_plural.items())
             for order, msgstr in ordered_plural:
                 plural.append(msgstr)

--- a/pojson/test_convert.py
+++ b/pojson/test_convert.py
@@ -18,6 +18,21 @@ def test_po2dict():
 
     assert result == {'': {}, u'Hello world': [None, u'Hallo wereld']}
 
+def test_po2dict_with_ctxt():
+    po = polib.POFile()
+    po.metadata = {}
+    entry = polib.POEntry(
+        msgctxt=u'system context',
+        msgid=u'Hello world',
+        msgstr=u'Hallo wereld')
+    po.append(entry)
+
+    result = po2dict(po)
+
+    assert result == {
+        '': {},
+        u'system context\x04Hello world': [None, u'Hallo wereld']}
+
 def test_po2dict_with_metadata():
     po = polib.POFile()
     po.metadata = {'Project-Id-Version': '1.0'}


### PR DESCRIPTION
[Javascript Gettext](http://jsgettext.berlios.de/) has [context feature](http://jsgettext.berlios.de/doc/html/Gettext.html#pgettext__msgctxt__msgid__) like [GNU gettext](http://www.gnu.org/software/gettext/). of course, [`po2json`](http://jsgettext.berlios.de/doc/html/po2json.html) can parse `msgctxt` properly.[check [this demo page](http://jsgettext.berlios.de/demo/index.html).]

This PR implements its feature.(it just put separator(`\u0004`) between `msgctxt` and `msgid` and using it for key.) 
